### PR TITLE
[feat] 마이페이지 로그아웃 기능 구현

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     'social_django',  # 소셜 인증 라이브러리
     'directory', # 초기 디렉터리 생성 
     'Tech_Stack',
+    'rest_framework_simplejwt.token_blacklist',  # 토큰 블랙리스트 앱 추가
 ]
 
 SITE_ID = 1


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

### 마이페이지 로그아웃 기능 구현

### ✨ Description

<!-- write down the work details and show the execution results. -->

- 리프레시 토큰을 입력하고 로그아웃 하면 쿠키의 토큰들이 사라집니다. (로그아웃이 post요청인 이유는 refresh토큰을 전달해야 하기 때문)
![image](https://github.com/user-attachments/assets/855bfe11-e9dd-4248-bf8d-8b2943500b93)

![image](https://github.com/user-attachments/assets/ca6e4949-653e-4878-9aa2-59897ae295d6)

- 메세지의 리다이렉트 경로로 가면 소셜로그인 로그아웃 페이지가 나옵니다. 추후 프론트와 연동할 때는 바로 리다이렉트 됩니다.
![image](https://github.com/user-attachments/assets/50f59628-f8ba-456e-8ce6-76b87a30bdbe)

![image](https://github.com/user-attachments/assets/0c246f87-18a5-4e61-b8cb-dac01c315bf9)


### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{84}
