### PR TITLE
[feat] 마이페이지 프로젝트 확인 기능 구현, 로그인 앱 API 명세 리팩토링

### DIFF
--- a/login/urls.py
+++ b/login/urls.py
@@ -4,7 +4,8 @@ from . import views
 urlpatterns = [
     path('', views.LoginGithubView.as_view(), name='login_auth_github'), # 깃허브 연동
     # GitHub OAuth 콜백 URL 추가
-    path('github/callback/',views.LoginGithubCallbackView.as_view(),name='login_github_callback'),
-    path('code/view/',views.CodeView.as_view(),name='code_view'),
-    path('profile/',views.MyPageView.as_view(),name='mypage_view'),
+    path('github/callback',views.LoginGithubCallbackView.as_view(),name='login_github_callback'),
+    path('code/view',views.CodeView.as_view(),name='code_view'),
+    path('profile',views.MyPageView.as_view(),name='mypage_view'),
+    path('profile/<int:project_id>',views.ProjectIDView.as_view(),name='project_id_view'),
 ]


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

### 마이페이지 프로젝트 확인 기능 구현, 로그인 앱 API 명세 리팩토링

### ✨ Description

<!-- write down the work details and show the execution results. -->

### 먼저 마이페이지(profile)에 들어가서 사용자가 만든 프로젝트들을 확인합니다.
**user_id  1이 만든 프로젝트입니다. 데이터베이스에서도 확인 가능합니다.**
**위에서부터 1, 2, 3 번입니다.**
![image](https://github.com/user-attachments/assets/cc5636e3-7dda-4396-a077-f02ad8b3cdbc)
![image](https://github.com/user-attachments/assets/93d86f5f-e407-4a34-adb5-b52fa65e85cf)

### 프로젝트를 누르면 해당 프로젝트의 제목, erd, 다이어그램을 보여줍니다. 추후 프론트와 상의 할 예정입니다.
![image](https://github.com/user-attachments/assets/310be03b-8949-4402-9ac2-d745f6198c37)
![image](https://github.com/user-attachments/assets/25688fa4-9906-4b29-b996-f2391d0c1057)

### 추가적으로 로그인 앱의 API 명세 리팩토링 했습니다. 수정해야 할 것은 .env의 리다이렉트 url과 깃허브 앱의 콜백 url을 http://localhost:8000/api/v1/login/code/view로 수정해야합니다.

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{94}
