### PR TITLE
[feat] 깃허브 아이디와 프로필 이미지를 전송하는 api 생성

### DIFF
--- a/login/urls.py
+++ b/login/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path('code/view',views.CodeView.as_view(),name='code_view'),
     path('profile',views.MyPageView.as_view(),name='mypage_view'),
     path('profile/<int:project_id>',views.ProjectIDView.as_view(),name='project_id_view'),
+    path('details',views.UserDetailsView.as_view(),name='user_datails_view'),
 ]

--- a/login/views.py
+++ b/login/views.py
@@ -414,3 +414,38 @@ class ProjectIDView(APIView):
                 {"error": "프로젝트를 찾을 수 없습니다."},
                 status=status.HTTP_404_NOT_FOUND
             )
+            
+class UserDetailsView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @swagger_auto_schema(
+        operation_summary="사용자 정보 조회 API",
+        responses={
+            200: openapi.Response(
+                description="사용자 정보 조회 성공",
+                schema=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "username": openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description="GitHub 사용자 이름"
+                        ),
+                        "profile_image": openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description="GitHub 사용자 프로필 이미지 URL"
+                        ),
+                    },
+                ),
+            ),
+            401: openapi.Response(
+                description="인증 실패 (JWT 토큰 누락 또는 유효하지 않음)"
+            ),
+        },
+    )
+    def get(self, request):
+        user = request.user
+        data = {
+            "username": user.github_username,
+            "profile_image": user.profile_image,
+        }
+        return Response(data, status=status.HTTP_200_OK)


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

### 깃허브 아이디와 프로필 이미지를 전송하는 api 생성

### ✨ Description

<!-- write down the work details and show the execution results. -->

**깃허브 아이디와 프로필 이미지를 전송하는 api 생성**
참고로 이제 콜백뷰에서 바로 리다이렉트 하기 때문에 콜백뷰에서 인가코드 입력하고 개발자도구의 쿠키에서 jwt토큰을 확인하셔야 합니다.

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{143}
