### PR TITLE
[feat] 리프레시 토큰으로 jwt토큰 다시 발급 및 마이페이지 수정

### DIFF
--- a/document/views.py
+++ b/document/views.py
@@ -148,10 +148,6 @@ def documents(request):
                     result=""  # 초기 result는 빈 문자열
                 )
 
-                # Project 생성 또는 가져오기
-                project_name = title
-                Project.objects.get_or_create(user=user, name=project_name)
-
                 document_id = document.id
 
                 # 스트리밍을 처리할 DocumentStream 객체 생성

--- a/login/serializers.py
+++ b/login/serializers.py
@@ -8,7 +8,7 @@ class LoginResponseSerializer(serializers.Serializer):
 class UserProfileSerializer(serializers.Serializer):
     github_username = serializers.CharField()
     email = serializers.EmailField()
-    project_names = serializers.ListField(
+    document_titles = serializers.ListField(
         child=serializers.CharField(),
         allow_empty=True
     )

--- a/login/urls.py
+++ b/login/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
     path('github/callback',views.LoginGithubCallbackView.as_view(),name='login_github_callback'),
     path('code/view',views.CodeView.as_view(),name='code_view'),
     path('profile',views.MyPageView.as_view(),name='mypage_view'),
-    path('profile/<int:project_id>',views.ProjectIDView.as_view(),name='project_id_view'),
+    path('profile/<int:document_id>',views.DocumentIDView.as_view(),name='document_id_view'),
     path('details',views.UserDetailsView.as_view(),name='user_datails_view'),
     path('refresh',views.RefreshTokenView.as_view(),name='refresh_token_view'),
 ]


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

### 리프레시 토큰으로 jwt토큰 다시 발급 및 마이페이지 수정

### ✨ Description
- 리프레시 토큰으로 jwt토큰 다시 발급 기능 수정했습니다. 이제 jwt토큰이 있으면 로그인 코드 다시 안 받아와도 되고 refresh누르고 string이라고만 입력하고 excute눌러도 다시 발급됩니다. 프론트에서는 401오류(만료) 나면 자동 api 호출로 다시 발급 됩니다.
<img width="407" alt="image" src="https://github.com/user-attachments/assets/bc3680ee-2aa3-49b0-bba6-461f552d0552" />

- 마이페이지 document_id로 받아오게 수정했습니다.
<!-- write down the work details and show the execution results. -->

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{Issue Number}
